### PR TITLE
strip leading/trailing white space and following inline comments from value

### DIFF
--- a/src/IniFile.jl
+++ b/src/IniFile.jl
@@ -60,7 +60,7 @@ function read(inifile::Inifile, stream::IO)
                     idx = max(i, j)
                 end
                 key = rstrip(s[1:idx-1])
-                val = lstrip(s[idx+1:end])
+                val = strip(split(s[idx+1:end],r"[\t, ][#,;]")[1])
                 current_section[key] = val
             end
         end


### PR DESCRIPTION
strip leading/trailing white space and following inline comments (if separated by at least a space or a tab) from value.
