### PR TITLE
Project.toml had the wrong UUID

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 authors = ["David de Laat", "Jeff Bezanson", "Jeff Bezanson", "Stefan Karpinski", "Stefan Karpinski"]
 name = "IniFile"
-uuid = "6d3e9c20-783a-11e8-259d-b3e6192296b0"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
 version = "0.5.0"
 
 [deps]


### PR DESCRIPTION
This needs to match what's in the General registry for already-registered packages.